### PR TITLE
Gains explicit URL for the ‘Report an Issue’ action. 

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
-blank_issues_enabled: false
-contact_links:
-    - name: esipDMP GitHub Issues
-      url: https://github.com/ESIPFed/esipDMP/issues/new/choose
-      about: Please report any issues here.
+blank_issues_enabled: true
+# contact_links: # If you prefer, you can direct people to external sites
+#     - name: esipDMP GitHub Issues
+#       url: https://github.com/ESIPFed/esipDMP/issues/new/choose 
+#       about: Please report any issues here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
-# contact_links: # If you prefer, you can direct people to external sites
-#     - name: esipDMP GitHub Issues
-#       url: https://github.com/ESIPFed/esipDMP/issues/new/choose 
-#       about: Please report any issues here.
+contact_links: # If you prefer, you can direct people to external sites
+     - name: Direct message
+       #url: https://github.com/ESIPFed/esipDMP/issues/new/choose 
+       about: Directly report any issues here.

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -10,6 +10,7 @@ website:
   title: "esipDMP: Primer on Best Practices and Tools for Data Management Planning"
   site-url: https://esipfed.github.io/esipDMP/
   repo-url: https://github.com/ESIPFed/esipDMP
+  issue-url: https://github.com/ESIPFed/esipDMP/issues/new/choose
   repo-actions: [edit, source, issue]
   
   page-navigation: true
@@ -21,7 +22,7 @@ website:
 
   page-footer: 
     left: "Eart Sciences Information Partners (ESIP) &copy; Data Stewardship Committee (2025)."
-    #right: "Built with Quarto and GitHub Pages."
+    right: "Built with [Quarto](https://quarto.org) and ♥."
   
   sidebar:
     title: "esipDMP Primer"

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -21,7 +21,7 @@ website:
   #     - about.qmd
 
   page-footer: 
-    left: "Eart Sciences Information Partners (ESIP) &copy; Data Stewardship Committee (2025)."
+    left: "Eart Sciences Information Partners (ESIP) Data Stewardship Committee (2025)."
     right: "Built with [Quarto](https://quarto.org) and ♥."
   
   sidebar:


### PR DESCRIPTION
This PR fixes missing links and YAML configurations in `_quarto.yml` and `.github/ISSUE_TEMPLATE/config.yml` to direct users to choose an issue from the template options. It also add some nice footer message to the main page. 
Closes #3.

## Testing
- Main page render well in local machine.
- Links are working