### PR TITLE
Gains `blank-issue` template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank-issue.md
+++ b/.github/ISSUE_TEMPLATE/blank-issue.md
@@ -1,0 +1,16 @@
+---
+name: Blank Issue
+about: Use this template to create a new issue.
+title: ''
+labels: ''
+assignees: ''
+---
+
+**What is the purpose of this issue?**
+Provide a brief description of what this issue is about.
+
+**What should be addressed or added?**
+Explain what needs to be addressed, added, or changed.
+
+**Additional context or references**
+Add any relevant context, examples, or references to help clarify the issue.


### PR DESCRIPTION
Introduces a "blank" issue. It is still a template, but broader. This is a work around `blank_issues_enabled: false` in ` config.yml`. We need `config.yml` to be set like that  to then direct users to an external link. The blank template help use have both a blank issue and an external link "issue".

Related to #2 and #3 