### PR TITLE
Gains `sections/` with initial scaffold for content.

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -43,7 +43,22 @@ website:
     contents:
       - text: "Welcome"
         href: index.qmd
-      
+      - text: "Research Outputs"
+        href: sections/outputs.qmd
+      - text: "Standardization of Data and Metadata"
+        href: sections/standardization.qmd
+      - text: "Access to Research Outputs"
+        href: sections/access.qmd
+      - text: "Roles and Responsibilities"
+        href: sections/roles_responsibilities.qmd
+      - text: "Persistent Identifiers (PIDs)"
+        href: sections/pids.qmd
+      - text: "Data Management"
+        href: sections/data_management.qmd
+      # - section: core-lessons/index.qmd
+      #   contents:        
+      #    - href: "core-lessons/mindset.qmd"
+      #      text: Mindset
 format:
   html:
     theme:

--- a/sections/access.qmd
+++ b/sections/access.qmd
@@ -1,0 +1,17 @@
+---
+title: "Access to Research Outputs"
+---
+
+## What Does Access Look Like?
+
+### Access
+- **Sharing**
+  - Mechanisms for sharing outputs (e.g., repositories, cloud storage).
+- **Provisions/Protection**
+  - Measures to protect sensitive or confidential data (e.g., encryption, access controls).
+- **Timeline for Availability/Access**
+  - When will products be shared or published (e.g., immediately, after embargo period).
+- **License**
+  - Licensing terms (e.g., Creative Commons, MIT License).
+- **Restrictions / Confidentiality / Proprietary Business Info**
+  - Any limitations on access due to confidentiality or proprietary concerns.

--- a/sections/data_management.qmd
+++ b/sections/data_management.qmd
@@ -1,0 +1,20 @@
+---
+title: "Data Management"
+---
+
+## Overview
+- Comprehensive plan for managing research data throughout its lifecycle.
+
+## Key Components
+- **Data Collection**
+  - Methods and tools for data collection.
+- **Data Storage**
+  - Secure and scalable storage solutions.
+- **Data Backup**
+  - Regular backups to prevent data loss.
+- **Data Archiving**
+  - Long-term preservation of data in trusted repositories.
+- **Data Sharing**
+  - Policies and platforms for sharing data with the broader community.
+- **Data Retention**
+  - Guidelines for retaining or disposing of data after project completion.

--- a/sections/outputs.qmd
+++ b/sections/outputs.qmd
@@ -1,0 +1,40 @@
+---
+title: "Research Outputs"
+---
+
+## What Research Outputs Are Being Produced?
+
+Research outputs include a variety of materials and data generated during the research process. These may include:
+
+- **Samples**
+  - Physical samples (e.g., biological, chemical, geological)
+  - Digital samples (e.g., scanned images, 3D models)
+- **Data**
+  - Raw data
+  - Processed data
+  - Metadata
+- **Collections**
+  - Curated sets of samples or data
+- **Software**
+  - Code, scripts, or applications developed for analysis
+- **Materials**
+  - Lab protocols, reagents, or experimental setups
+- **Models**
+  - Statistical, mathematical, or computational models
+- **Documents/Posters/Pre-prints/Publications/Videos**
+  - Research papers, conference posters, pre-prints, and multimedia content
+
+## Number and Size of Research Outputs
+
+- **Number of files, samples, collections, etc.**
+  - Estimated count of each type of output.
+- **Size of each file, sample, etc.**
+  - File sizes (e.g., MB, GB, TB) for digital outputs.
+  - Physical dimensions or quantities for physical samples.
+
+## Metadata Critical for Data Interpretation and Reuse
+
+- **Sensor metadata**
+  - Information about instruments or sensors used to collect data.
+- **Sampling effort metadata**
+  - Details about sampling methods, locations, and conditions.

--- a/sections/pids.qmd
+++ b/sections/pids.qmd
@@ -1,0 +1,15 @@
+---
+title: "Persistent Identifiers (PIDs)"
+---
+
+## Research Outputs
+- Use of PIDs (e.g., DOI, Handle, ARK) to uniquely identify outputs.
+
+## Formats and Standards
+- PIDs for metadata schemas and standards.
+
+## Access
+- PIDs for access protocols and repositories.
+
+## Data Management
+- PIDs for datasets and related documentation.

--- a/sections/roles_responsibilities.qmd
+++ b/sections/roles_responsibilities.qmd
@@ -1,0 +1,18 @@
+---
+title: "Roles and Responsibilities"
+---
+
+## Data Manager
+- Oversees data management practices.
+- Ensures compliance with the Data Management Plan (DMP).
+
+## Point of Contact for the DMP
+- Primary individual responsible for DMP updates and communication.
+- Ensures the DMP is followed by the research team.
+
+## Contractor/Consultant/Third Party Contact Information
+- Details of external parties involved in data management.
+
+## Plan for Personnel Turnover/Transfer
+- Procedures for transferring responsibilities in case of personnel changes.
+- Documentation of roles and access permissions.

--- a/sections/standardization.qmd
+++ b/sections/standardization.qmd
@@ -1,0 +1,17 @@
+---
+title: "Standardization of Data and Metadata"
+---
+
+## How Will It Be Standardized?
+
+### Data / Metadata Formats
+- Use of widely accepted formats (e.g., CSV, JSON, HDF5 for data; XML, JSON-LD for metadata).
+- Consistent naming conventions and file structures.
+
+### Standards
+- Adherence to domain-specific standards (e.g., Darwin Core for biodiversity data, DICOM for medical imaging).
+- Compliance with FAIR principles (Findable, Accessible, Interoperable, Reusable).
+
+### QA/QC Methods
+- Implementation of quality assurance and quality control processes.
+- Regular audits and validation checks to ensure data integrity.


### PR DESCRIPTION
# Draft Markdown Files for Research Outputs and Data Management Documentation

## Summary
This PR adds a set of draft Quarto Markdown files to document research outputs, data management practices, standardization, access, roles and responsibilities, and persistent identifiers (PIDs).
## Changes Included
- Added the following Markdown files:
  - `sections/research_outputs.qmd`
  - `sections/standardization.qmd`
  - `sections/access.qmd`
  - `sections/roles_responsibilities.qmd`
  - `sections/pids.qmd`
  - `sections/data_managementq.md`
- Organized files into a logical structure for easy navigation.


## Testing
- No code changes are included in this PR, so no testing is required.
- Markdown files have been previewed locally to ensure proper formatting.

## To-Do
- [ ] Test workflow in GH Codespaces @jibarozzo 

