### PR TITLE
Changing the order of the Life_cycle page to be after the Welcome page

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -43,6 +43,8 @@ website:
     contents:
       - text: "Welcome"
         href: index.qmd
+      - text: "Data Life Cycle"
+        href: sections/data_lifecycle.qmd
       - text: "Research Outputs"
         href: sections/outputs.qmd
       - text: "Standardization of Data and Metadata"
@@ -53,8 +55,7 @@ website:
         href: sections/roles_responsibilities.qmd
       - text: "Persistent Identifiers (PIDs)"
         href: sections/pids.qmd
-      - text: "Data Life Cycle"
-        href: sections/data_lifecycle.qmd
+
       # - section: core-lessons/index.qmd
       #   contents:        
       #    - href: "core-lessons/mindset.qmd"


### PR DESCRIPTION
Fixing the order of the pages in the TOC. 

This relates to #28 and # 