### PR TITLE
redirect author links to works cited page in new tab

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -43,10 +43,10 @@ website:
            text: "Welcome"
          - href: sections/introduction/data_lifecycle.qmd
            text: "Data Life Cycle"
-         - href: sections/introduction/feedback.qmd
-           text: "Feedback"
          - href: sections/introduction/how_to.qmd
            text: "How to use this guide"
+         - href: sections/introduction/feedback.qmd
+           text: "Feedback"
       - section: "DMP Content"
         contents:
          - href: sections/dmp_content/outputs.qmd

--- a/sections/dmp_content/access.qmd
+++ b/sections/dmp_content/access.qmd
@@ -18,7 +18,7 @@ See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-
 -  Mechanisms for sharing outputs (e.g., repositories, cloud storage).
 
 ::: {.callout-note}
-## BCO-DMO: [Church](https://drive.google.com/file/d/1lFfmFJ0FRqvj4HQU6FX-QFne-2XYPQ6y/view?usp=share_link)
+## BCO-DMO: [Church](../references_resources/works_cited.qmd){target="_blank"}
 *To increase accessibility to project data and the dissemination of our research findings—particularly among scientists from developing countries—we will make every effort to publish our results as open-access articles or within open-access journals.*
 :::
 
@@ -31,11 +31,11 @@ See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-
 -  Where the data will be stored (e.g., institutional repository, public archive).
 
 ::: {.callout-note}
-## BCO-DMO: [Saito](https://drive.google.com/file/d/1xJ8EiH436Fr95XrIEsvyYHoQv0mErSwB/view?usp=share_link)
+## BCO-DMO: [Saito](../references_resources/works_cited.qmd){target="_blank"}
 *R2R will ensure that the original underway measurements are archived permanently at NCEI and/or NGDC as appropriate. BCO-DMO will also ensure that project data are submitted to the appropriate national data archive. The PI will work with R2R and BCO-DMO to ensure data are archived appropriately and that proper and complete documentation are archived along with the data. All processed data will be submitted to BCO-DMO. Sequence data will be submitted to NCBI and raw mass spectrometry data will be submitted to ProteomeXchange.*
 :::
 ::: {.callout-note}   
-## BCO-DMO: [Reitzel](https://drive.google.com/file/d/19I3y-pgxbPr-T7yITp5LMhfS7gT4TqOm/view?usp=share_link)
+## BCO-DMO: [Reitzel](../references_resources/works_cited.qmd){target="_blank"}
 *Sequence data will be archived at NCBI GenBank or SRA, code will be archived on GitHub and processed data files (e.g., vcf files) will be deposited in Dryad. BCO-DMO ensures that the data are archived properly at the appropriate National Data Archive for long-term archive preservation.*
 :::
 
@@ -52,12 +52,12 @@ See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-
 -  When will products be shared or published (e.g., immediately, after embargo period).
 
 ::: {.callout-note}
-## BCO-DMO: [Church](https://drive.google.com/file/d/1lFfmFJ0FRqvj4HQU6FX-QFne-2XYPQ6y/view?usp=share_link)
+## BCO-DMO: [Church](../references_resources/works_cited.qmd){target="_blank"}
 *All of the data generated in this study will be made publicly available upon publication in a peer-reviewed journal, or within two years of the completion of the project. […] Shipboard underway data will be made available within one year via the Rolling Deck to Repository.*
 :::
 
 ::: {.callout-note}
-## BCO-DMO: [Greer](https://drive.google.com/file/d/1OTn2YkAbrXQBt3CN2hL4ras1sewSg5Vi/view?usp=share_link)
+## BCO-DMO: [Greer](../references_resources/works_cited.qmd){target="_blank"}
 *Once the data have been collected and quality controlled, we will ensure all data are publicly available within two years. In general, we do not intend to impose any data embargos, with the exception of student generated data that will be used for the completion of student theses and publications.*
 :::
 
@@ -70,7 +70,7 @@ See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-
 -  Licensing terms (e.g., Creative Commons, MIT License).
 
 ::: {.callout-note}
-## BCO–DMO: [Church](https://drive.google.com/file/d/1lFfmFJ0FRqvj4HQU6FX-QFne-2XYPQ6y/view?usp=share_link)
+## BCO–DMO: [Church](../references_resources/works_cited.qmd){target="_blank"}
 *All data from this project are considered within the public domain for all not-for-profit uses and there will be no permission restrictions placed on use of the data.*
 :::
 
@@ -86,7 +86,7 @@ Comments
 :::
 
 ::: {.callout-note}
-## [MCR-LTER](https://drive.google.com/file/d/1rNYVmb7wMWjaDMhHGMEFG5hsnr8yhz56/view?usp=share_link)
+## [MCR-LTER](../references_resources/works_cited.qmd){target="_blank"}
 *Our data access/data use policy is the Creative Commons license CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/). The user is free to use and adapt the data while giving appropriate credit without any other restrictions. In our data use policy, we make a few additional recommendations for collaboration and suggest that users contact the appropriate MCR personnel if they have any questions or concerns about the data, but these recommendations do not change the general license text.*
 :::
 
@@ -104,12 +104,12 @@ See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-
 -  Limitations on access due to confidentiality (e.g. personal data) or proprietary concerns (e.g. business-critical data).  
 
 ::: {.callout-note}
-## BCO-DMO: [Greer](https://drive.google.com/file/d/1OTn2YkAbrXQBt3CN2hL4ras1sewSg5Vi/view?usp=share_link)
+## BCO-DMO: [Greer](../references_resources/works_cited.qmd){target="_blank"}
 *We do not expect that the data we will generate will require any exceptional arrangements due to questions of ethical restrictions or release of indigenous knowledge.*
 :::
 
 ::: {.callout-note}
-## BCO-DMO:  [Church](https://drive.google.com/file/d/1lFfmFJ0FRqvj4HQU6FX-QFne-2XYPQ6y/view?usp=share_link)
+## BCO-DMO:  [Church](../references_resources/works_cited.qmd){target="_blank"}
 *There are no ethical and privacy issues with these data. There are no human research subjects in our study. The dataset from this project will not be copyrighted.*
 :::
 

--- a/sections/dmp_content/outputs.qmd
+++ b/sections/dmp_content/outputs.qmd
@@ -20,7 +20,7 @@ See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-
 -  Research papers, conference posters, pre-prints, and multimedia content
 
 ::: {.callout-note}
-## BCO-DMO: [Mullineaux #2453](https://drive.google.com/file/d/1-N-bHKeJbC1QTouZVT5Ae2MMSAG9CEYA/view?usp=share_link)
+## BCO-DMO: [Mullineaux #2453](../references_resources/works_cited.qmd){target="_blank"}
 *Imagery at the seafloor will include NDSF vehicle imagery (e.g., 4K video) and PI-provided imagery (e.g., time-lapse still).*
 :::
 
@@ -31,7 +31,7 @@ See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-
 -  Statistical, mathematical, or computational models
 
 ::: {.callout-note}
-## BCO-DMO: [Bianchi](https://drive.google.com/file/d/1pR_HCs9ayvXZXwkAENdRYJ9utfwax6-B/view?usp=share_link)
+## BCO-DMO: [Bianchi](../references_resources/works_cited.qmd){target="_blank"}
 *Output from model simulations, which will include both physical (T, S, velocities) and biogeochemical (tracer, rates, fluxes) variables. The raw output will be post-processed and analyzed for presentation at meetings and for publication in scientific journals. For model output from the main set of simulations (Table 1 in the proposal), standard model fields (e.g. physical and biogeochemical tracers, current velocities, and the main biogeochemical rates) at monthly resolution will be provided to, and made available through, BCO-DMO and NOAA NCEI in standard NetCDF format.*
 :::
 
@@ -39,7 +39,7 @@ See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-
 -  Physical samples (e.g., biological, chemical, geological)
 
 ::: {.callout-note}
-## BCO-DMO: [Mullineaux #2453](https://drive.google.com/file/d/1-N-bHKeJbC1QTouZVT5Ae2MMSAG9CEYA/view?usp=share_link)
+## BCO-DMO: [Mullineaux #2453](../references_resources/works_cited.qmd){target="_blank"}
 *Physical samples will include animals, rocks, and water column samples. Rocks and animal specimens for which we extract gut contents will be assigned unique sample identifiers, important for provenance for subsamples to be analyzed for microbes.*
 :::
 
@@ -64,7 +64,7 @@ See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-
 -  Physical dimensions or quantities for physical samples.
     
 ::: {.callout-note}
-## LTER: [Sosik](https://drive.google.com/file/d/1-kTwz8I46snB0tfNk4U8bk8suVjF8xjG/view?usp=drive_link)
+## LTER: [Sosik](../references_resources/works_cited.qmd){target="_blank"}
 *By mid-year 6 of our project, our IM team stores \~60 TB of data (\~55 on premises and \~5 cloud). For WHOI’s institutional research data storage (RDS) on premises, we have \>40 TB to share within WHOI a subset of our towed plankton imaging data, 12 TB for a subset of our coupled physical-biological model output, and 1 TB for (low-volume) data products including those served by our web-based REST API. However, additional storage is required for plankton imagery (e.g., PI Sosik’s network attached storage serving \~10 TB publicly available IFCB data), acoustic data collected by vessels and Stingray towed vehicle, and physical and coupled biological-physical model output; these and some other high-volume data types (e.g., high throughput sequencing data) are necessarily managed by PIs*.
 :::
 
@@ -82,7 +82,7 @@ Comments
 
 
 ::: {.callout-note}
-## BCO-DMO: [Alexander]()
+## BCO-DMO: [Alexander](../references_resources/works_cited.qmd){target="_blank"}
 
 *Description of data types, number of experiments performed, file types generated, and repositories for submission*
 
@@ -101,7 +101,7 @@ See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-
 -  Information about instruments or sensors used to collect data.
 
 ::: {.callout-note}
-## BCO–DMO: [Church](https://drive.google.com/file/d/1lFfmFJ0FRqvj4HQU6FX-QFne-2XYPQ6y/view?usp=share_link)
+## BCO–DMO: [Church](../references_resources/works_cited.qmd){target="_blank"}
 *All underway optical data including imaging flow cytometry will be time-synchronized with the ship’s GPS and thermosalinograph. At sea all data will be visualized in real time to evaluate data quality and instrument stability; data will be stored on a customized raspberry-PI based data logger and backed up onto a separate hard drive. Post-cruise, all continuous optical data will be merged to 1-min averages and submitted to BCO-DMO; Imaging flow cytometry data are sampled at \~20 min intervals; a composite cruise file of all imaged particles and their individual morphometrics and optical properties will be generated and submitted to BCO-DMO.*
 :::
 
@@ -109,7 +109,7 @@ See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-
 -  Details about sampling methods, locations, and conditions
 
 ::: {.callout-note}
-## BCO-DMO: [Reitzel](https://drive.google.com/file/d/19I3y-pgxbPr-T7yITp5LMhfS7gT4TqOm/view?usp=share_link)
+## BCO-DMO: [Reitzel](../references_resources/works_cited.qmd){target="_blank"}
 *Sequence data will be annotated with essential information for each sample, which will include description of the sample (e.g., location of origin for population, date), method for library generation, and the sequencing method. These data tags for description will be included with data submitted to SRA and BCO-DMO. Nucleic acids extracted from collected animals will be labeled with precise site of origin (latitude, longitude), date of collection, and species and archived in the Reitzel and Burt laboratories. Field temperature data will be stored in flat ASCII files, which can be read easily by different software packages. Field data will include date, time, latitude, longitude, and temperature, as appropriate.*
 :::
 
@@ -122,8 +122,8 @@ See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-
 PIDs help disambiguate sources and versions of data or information.   
 
 Common PIDs for research outputs include:  
--  [DOI](https://www.doi.org/)  
--  [ARK](https://arks.org/about/)  
+-  [DOI](https://www.doi.org/){target="_blank"}  
+-  [ARK](https://arks.org/about/){target="_blank"}  
 
     
 

--- a/sections/dmp_content/roles_responsibilities.qmd
+++ b/sections/dmp_content/roles_responsibilities.qmd
@@ -23,7 +23,7 @@ See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-
 -   Ensures the DMP is followed by the research team.
 
 ::: {.callout-note}
-### BCO-DMO: [Mullineaux #2453](https://drive.google.com/file/d/1-N-bHKeJbC1QTouZVT5Ae2MMSAG9CEYA/view?usp=share_link) 
+### BCO-DMO: [Mullineaux #2453](../references_resources/works_cited.qmd){target="_blank"} 
 *Lead PI will ensure compliance to this data management plan.*
 :::  
 
@@ -36,7 +36,7 @@ See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-
 -   May be the primary individual responsible for DMP updates.
 
 ::: {.callout-note}
-### BCO-DMO: [Mullineaux #2453](https://drive.google.com/file/d/1-N-bHKeJbC1QTouZVT5Ae2MMSAG9CEYA/view?usp=share_link)
+### BCO-DMO: [Mullineaux #2453](../references_resources/works_cited.qmd){target="_blank"}
 -  *Observations at seafloor: All PIs*
 -  *Imagery at seafloor - PI3 and PI4*
 -  *Physical sample cataloging:*
@@ -59,7 +59,7 @@ See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-
 -  May ensure the DMP is followed by the research team.
 
 ::: {.callout-note}
-### BCO-DMO: [Mullineaux #2453](https://drive.google.com/file/d/1-N-bHKeJbC1QTouZVT5Ae2MMSAG9CEYA/view?usp=share_link):
+### BCO-DMO: [Mullineaux #2453](../references_resources/works_cited.qmd){target="_blank"}
 -  *Lead PI will ensure compliance to this data management plan.*
 -  *Details of external parties involved in data management.*
 :::

--- a/sections/dmp_content/standardization.qmd
+++ b/sections/dmp_content/standardization.qmd
@@ -13,7 +13,7 @@ See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-
 -   Use of widely accepted formats (e.g., CSV, JSON, HDF5 for data; XML, JSON-LD for metadata).
 
 ::: {.callout-note}
-## BCO-DMO: [Mullineaux #2453](https://drive.google.com/file/d/1-N-bHKeJbC1QTouZVT5Ae2MMSAG9CEYA/view?usp=share_link)
+## BCO-DMO: [Mullineaux #2453](../references_resources/works_cited.qmd){target="_blank"}
 *Field observation data will be stored in flat ASCII files, which can be read easily by different software packages. Observational and experimental data from processed samples will be stored mainly as spreadsheets. Imagery from the seafloor will be stored in original resolution (this will be the biggest data volume in this project). Metadata will be prepared in accordance with BCO-DMO conventions (i.e. using the BCO-DMO metadata forms) and will include detailed descriptions of collection and analysis procedures.*
 :::
 
@@ -24,14 +24,14 @@ See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-
 -  Adherence to domain-specific standards (e.g., Darwin Core for biodiversity data, DICOM for medical imaging).
 
 ::: {.callout-note}
-## BCO-DMO: [Mullineaux #2453](https://drive.google.com/file/d/1-N-bHKeJbC1QTouZVT5Ae2MMSAG9CEYA/view?usp=share_link)
+## BCO-DMO: [Mullineaux #2453](../references_resources/works_cited.qmd){target="_blank"}
 *Specifically for animals: We will utilize the World Register of Marine Species (WoRMS) taxonomic classification. We will standardize to Darwin Core format to provide occurrence data to OBIS and GBIF. Specifically for microbes: Genetic sequence data will be prepared in accordance with the minimum information about a marker gene sequence (MIMARKS) and about a metagenome sequence (MIMS) developed by the Genomic Standards Consortium, with quality control screening of raw reads from 16S/18S rRNA sequencing and raw metagenomic sequences. Specifically for minerals: Rock samples will be assigned International Geo Sample Numbers (IGSN) through SESAR (System for Earth Sample Registration)*
 :::
 
 -  Compliance with FAIR principles (Findable, Accessible, Interoperable, Reusable).
 
 ::: {.callout-note}
-## LTER: [Sosik](https://drive.google.com/file/d/1-kTwz8I46snB0tfNk4U8bk8suVjF8xjG/view?usp=drive_link)
+## LTER: [Sosik](../references_resources/works_cited.qmd){target="_blank"}
 *To contribute FAIR (Findable, Accessible, Interoperable, Reusable) data products to DataONE and other community repositories, our IM team uses non-proprietary data formats, standardizes metadata, and promotes the use of controlled vocabularies.*
 :::
 
@@ -46,11 +46,11 @@ See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-
 -  Regular audits and validation checks to ensure data integrity.
 
 ::: {.callout-note} 
-## BCO-DMO: [Saito](https://drive.google.com/file/d/1xJ8EiH436Fr95XrIEsvyYHoQv0mErSwB/view?usp=share_link)
+## BCO-DMO: [Saito](../references_resources/works_cited.qmd){target="_blank"}
 *Quality flags will be assigned according to the ODS IODE Quality Flag scheme (IOC Manuals and Guides, 54, volume 3; [http://www.iode.org/mg54_3](http://www.iode.org/mg54_3)*.
 :::
 
 ::: {.callout-note}
-## IOOS: [SCCOOS](https://sccoos.org/)
+## IOOS: [SCCOOS](../references_resources/works_cited.qmd){target="_blank"}
 *For sources that do not provide quality flags, the SCCOOS DMAC Sub-System runs QARTOD tests after ingesting observation data. Tests are run using the open-source [ioos_qc library](https://github.com/ioos/ioos_qc), which implements a suite of QARTOD tests as well as other quality control algorithms. The quality test code and test thresholds are documented and publicly available through the CalOOS Data Portal. Links to the ioos_qc methods used are available both within data charts and on sensor pages within the CalOOS Data Portal. Thresholds used for each test are also viewable on sensor pages and users are linked to the test code in GitHub.*
 :::


### PR DESCRIPTION
closes issue #54 by updating author links in callout boxes to redirect to the Works Cited page, and open in a new tab