### PR TITLE
DMP Common Standards links (Needs consistent hyperlink format)

### DIFF
--- a/sections/dmp_content/access.qmd
+++ b/sections/dmp_content/access.qmd
@@ -6,7 +6,7 @@ title: "Access to Research Outputs"
 
 *Describe how access to the research outputs will be provided (e.g., by publishing with a public domain license in a robust repository).  *
 
-See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table)/[dataset](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dataset_table)/[distribution](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#distribution_table) 
+See [DMP Common Standard](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table): [`distribution`](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#distribution_table) 
 
 -  Consider using persistent identifiers (PIDs) for access protocols. 
 
@@ -26,7 +26,7 @@ See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-
 
 *Describe the steps your project team will take to secure long-term availability of project data, and research outputs. This might include publishing data in robust repositories with strong sustainability plans, archiving back-up copies of data in long-term institutional cloud storage, including data maintenance in future funding requests and institutional budgets, and creating a long-term plan to ensure data remain available as staff change and data needs change.  *
 
-See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table)/[dataset](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dataset_table)/[preservation_statement](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dataset_preservation) 
+See [DMP Common Standard](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table): [`preservation_statement`](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dataset_preservation) 
 
 -  Where the data will be stored (e.g., institutional repository, public archive).
 
@@ -47,7 +47,7 @@ See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-
 
 *Describe any timelines for making data available that are mandated (e.g., by a funder) or planned by the project leads.  *
 
-See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table)/[dataset](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dataset_table)/[distribution](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#distribution_table)/[available_until](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#distribution_available_until)
+See [DMP Common Standard](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table): [`available_until`](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#distribution_available_until)
 
 -  When will products be shared or published (e.g., immediately, after embargo period).
 
@@ -65,7 +65,7 @@ See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-
 
 *Describe any licensing requirements from funders, participating organizations, or government agencies, including a species license (e.g. [CC-BY](https://creativecommons.org/licenses/by/4.0/deed.en)) or data use agreement.  *
 
-See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table)/[dataset](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dataset_table)/[license](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#license_table)
+See [DMP Common Standard](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table): [`license`](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#license_table)
 
 -  Licensing terms (e.g., Creative Commons, MIT License).
 
@@ -95,11 +95,7 @@ Comments
 *Describe any restrictions, embargoes, or other methods that will be applied to the data and research outputs, the methods for applying them, and for how long they will be applied. *
 
 
-See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table)/[dataset](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dataset_table)/[distribution](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#distribution_table)/[data_access](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#distribution_data_access)
-
-See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table)/[dataset](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dataset_table)/[personal_data](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dataset_personal_data)
-
-See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table)/[dataset](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dataset_table)/[sensitive_data](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dataset_sensitive_data)
+See [DMP Common Standard](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table): [`data_access`](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#distribution_data_access), [`personal_data`](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dataset_personal_data), &[`sensitive_data`](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dataset_sensitive_data)
 
 -  Limitations on access due to confidentiality (e.g. personal data) or proprietary concerns (e.g. business-critical data).  
 

--- a/sections/dmp_content/access.qmd
+++ b/sections/dmp_content/access.qmd
@@ -95,7 +95,7 @@ Comments
 *Describe any restrictions, embargoes, or other methods that will be applied to the data and research outputs, the methods for applying them, and for how long they will be applied. *
 
 
-See [DMP Common Standard](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table): [`data_access`](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#distribution_data_access), [`personal_data`](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dataset_personal_data), &[`sensitive_data`](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dataset_sensitive_data)
+See [DMP Common Standard](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table): [`data_access`](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#distribution_data_access), [`personal_data`](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dataset_personal_data), & [`sensitive_data`](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dataset_sensitive_data)
 
 -  Limitations on access due to confidentiality (e.g. personal data) or proprietary concerns (e.g. business-critical data).  
 

--- a/sections/dmp_content/outputs.qmd
+++ b/sections/dmp_content/outputs.qmd
@@ -6,7 +6,7 @@ title: "Research Outputs"
 
 *Research outputs include a variety of data and materials generated during the research process. Given the planned project and data collection, provide the most accurate estimate possible of the types of research outputs. This information will help calculate data/sample storage needs, and may help determine where the data can be published or archived.  *
 
-See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table)/[dataset](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dataset_table)
+See DSee [DMP Common Standard](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table): [`dataset`](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dataset_table)
 
 ### Collections
 -  Curated sets of samples or data
@@ -58,7 +58,7 @@ See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-
 
 ### Size of each file, sample, etc.
 
-See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table)/[dataset](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dataset_table)/[distribution](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#distribution_table)/[byte_size](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#distribution_byte_size)
+See [DMP Common Standard](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table): [`byte_size`](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#distribution_byte_size)
 
 -  File sizes (e.g., MB, GB, TB) for digital outputs.
 -  Physical dimensions or quantities for physical samples.
@@ -95,7 +95,7 @@ Comments
 
 *Describe the accompanying information that is needed to interpret the data, such as effort or calibration information. Describe what other data will be shared to enable interpretation of the data. This may include metadata (e.g., about sensors or other equipment), temporal and spatial details, or effort data (e.g., from observational surveys). *
 
-See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table)/[dataset](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dataset_table)/[metadata](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#metadata_table)
+See [DMP Common Standard](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table): [`metadata`](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#metadata_table)
 
 ### Sensor / instrument metadata
 -  Information about instruments or sensors used to collect data.
@@ -117,7 +117,7 @@ See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-
 
 *A PID is a long-lasting digital reference to an object, contributor, or organization, [“a code which remains constant as a means of identifying a digital object regardless of changes to its location on the internet”](https://search.credoreference.com/content/entry/macqdict/persistent_identifier/0?institutionId=499)*
 
-See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table)/[dataset](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dataset_table)/[dataset_id](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dataset_id_table)
+See [DMP Common Standard](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table): [`dataset_id`](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dataset_id_table)
 
 PIDs help disambiguate sources and versions of data or information.   
 

--- a/sections/dmp_content/outputs.qmd
+++ b/sections/dmp_content/outputs.qmd
@@ -6,7 +6,7 @@ title: "Research Outputs"
 
 *Research outputs include a variety of data and materials generated during the research process. Given the planned project and data collection, provide the most accurate estimate possible of the types of research outputs. This information will help calculate data/sample storage needs, and may help determine where the data can be published or archived.  *
 
-See DSee [DMP Common Standard](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table): [`dataset`](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dataset_table)
+See [DMP Common Standard](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table): [`dataset`](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dataset_table)
 
 ### Collections
 -  Curated sets of samples or data

--- a/sections/dmp_content/roles_responsibilities.qmd
+++ b/sections/dmp_content/roles_responsibilities.qmd
@@ -13,7 +13,7 @@ Wood-Charlson EM, Crockett Z, Erdmann C, Arkin AP, Robinson CB (2022) **Ten simp
 
 *The key roles are included below: Principal Investigator, Data Manager, Point of Contact for the DMP.  Other roles that could be included here include: Data Provider, Data Collector, Data Analyst, Data Engineer, GIS Analyst, Contractor, Consultant.*
 
-See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table)/[contributor](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_contributor_table)
+See [DMP Common Standard](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table): [`contributor`](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_contributor_table)
 
 -   Consider using persistent identifiers (PIDs), such as [ORCiD](https://orcid.org), to identify and disambiguate personnel
 
@@ -52,7 +52,7 @@ See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-
 
 ### Point of Contact for the DMP
 
-See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table)/[contact](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_contact_table)
+See [DMP Common Standard](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table): [`contact`](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_contact_table)
 
 -  Primary individual responsible for DMP updates and communication.
 
@@ -76,7 +76,7 @@ See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-
 
 ## Plan for Personnel Turnover/Transfer
 
-See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table)/[dataset](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dataset_table)/[preservation_statement](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dataset_preservation)
+See [DMP Common Standard](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table): [`preservation_statement`](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dataset_preservation)
 
 -  Procedures for transferring responsibilities in case of personnel changes.
 
@@ -85,9 +85,7 @@ See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-
 
 ## Funder identification
 
-See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table)/[contact](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_contact_table)/[contact_id](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#contact_id_table)
-
-See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table)/[contributor](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_contributor_table)/[contributor_id](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#contributor_id_table)
+See [DMP Common Standard](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table): [`contact_id`](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#contact_id_table) & [`contributor_id`](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#contributor_id_table)
 
 -  Persistent identifiers (PIDs) help identify the support for the research  
     -   [RAID](https://raid.org) - a project meta-PID  

--- a/sections/dmp_content/standardization.qmd
+++ b/sections/dmp_content/standardization.qmd
@@ -10,7 +10,7 @@ Generally, the request from funding organizations is framed something like this:
 
 ### Formats
 
-See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table)/[dataset](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dataset_table)/[distribution](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#distribution_table)/[format](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#distribution_format)
+See [DMP Common Standard](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table): [`format`](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#distribution_format)
 
 -   Use of widely accepted formats (e.g., CSV, JSON, HDF5 for data; XML, JSON-LD for metadata).
 
@@ -21,7 +21,7 @@ See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-
 
 ### Standards
 
-See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table)/[dataset](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dataset_table)/[metadata](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#metadata_table)
+See [DMP Common Standard](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table): [`metadata`](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#metadata_table)
 
 -  Adherence to domain-specific standards (e.g., Darwin Core for biodiversity data, DICOM for medical imaging).
 
@@ -42,7 +42,7 @@ See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-
 
 ## QA/QC Methods
 
-See DMP Common Standard: [dmp](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table)/[dataset](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dataset_table)/[data_quality_assurance](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dataset_quality_assurance)
+See [DMP Common Standard](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dmp_table): [`data_quality_assurance`](https://github.com/RDA-DMP-Common/RDA-DMP-Common-Standard#dataset_quality_assurance)
 
 -  Implementation of quality assurance and quality control processes.
 -  Regular audits and validation checks to ensure data integrity.


### PR DESCRIPTION
This PR partially addresses #44 by standardizing links to DMP Common Standards. Related to #44 #48 

TODO

- [ ] Populate Works Cited